### PR TITLE
Always ask for the current value in the context and do not memoize

### DIFF
--- a/lib/permission_policy/authorization.rb
+++ b/lib/permission_policy/authorization.rb
@@ -1,6 +1,6 @@
 module PermissionPolicy
   class Authorization
-    attr_reader :preconditions, :verified
+    attr_reader :preconditions, :verified, :context
 
     def initialize(context)
       @preconditions = []

--- a/lib/permission_policy/strategies/base_strategy.rb
+++ b/lib/permission_policy/strategies/base_strategy.rb
@@ -17,7 +17,7 @@ module PermissionPolicy
       def initialize(authorization, action = nil, options = {})
         authorization.preconditions.each do |attribute|
           self.class.send(:attr_accessor, attribute)
-          instance_variable_set(:"@#{attribute}", authorization.public_send(attribute))
+          instance_variable_set(:"@#{attribute}", authorization.context.public_send(attribute))
         end
 
         self.action = action

--- a/spec/permission_policy/strategies/base_strategy_spec.rb
+++ b/spec/permission_policy/strategies/base_strategy_spec.rb
@@ -3,7 +3,8 @@ module PermissionPolicy
     RSpec.describe BaseStrategy do
 
       context 'valid' do
-        let(:authorization) { double('authorization', preconditions: [:current_user], current_user: 'me') }
+        let(:context) { double('context', current_user: 'me') }
+        let(:authorization) { double('authorization', preconditions: [:current_user], context: context) }
         let(:action) { :foo }
         let(:options) { { something: 'nice' } }
 


### PR DESCRIPTION
If the values passed to the `base_strategy` are memoized we can run into a problem while testing permissions in a controller spec. Within the spec a user can chang, but every strategy will use the `current_user` from the first login.
